### PR TITLE
Rely on inference to identify the required PinFunction & implement basic support of embedded_hal 1.0-alpha.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,13 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-embedded-hal = "*"
-embedded-time = "*"
-rp2040-hal = { git = "https://github.com/rp-rs/rp-hal.git", branch = "main" }
-pio = { git = "https://github.com/rp-rs/pio-rs.git", branch = "main" }
-nb = "1.0.0"
 cortex-m = "0.7.3"
+eh1_0_alpha = { version = "=1.0.0-alpha.5", package = "embedded-hal", optional = true }
+embedded-hal = "0.2.6"
+embedded-time = "0.12.0"
+nb = "1.0.0"
+pio = { git = "https://github.com/rp-rs/pio-rs.git", branch = "main" }
+rp2040-hal = { git = "https://github.com/rp-rs/rp-hal.git", branch = "main" }
 
 [patch.'https://github.com/rp-rs/pio-rs.git']
 pio = { path = "../pio-rs" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -609,3 +609,39 @@ where
         self.finish()
     }
 }
+
+#[cfg(feature = "eh1_0_alpha")]
+mod eh1_0_alpha {
+    use super::Error;
+    use super::I2C;
+
+    impl<A, P, SM, SDA, SCL> eh1::Write for I2C<'_, P, SM, SDA, SCL>
+    where
+        A: Copy + AddressMode + Into<u16> + 'static,
+        P: PIOExt + FunctionConfig,
+        SM: ValidStateMachine<PIO = P>,
+        SDA: PinId,
+        SCL: PinId,
+        Function<P>: ValidPinMode<SDA> + ValidPinMode<SCL>,
+    {
+        type Error = Error;
+
+        fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Error> {
+            Write::write(self, addr, bytes)
+        }
+    }
+    impl<T: Deref<Target = Block>, PINS> eh1::WriteRead for I2C<T, PINS, Controller> {
+        type Error = Error;
+
+        fn write_read(&mut self, addr: u8, bytes: &[u8], buffer: &mut [u8]) -> Result<(), Error> {
+            WriteRead::write_read(self, addr, bytes, buffer)
+        }
+    }
+    impl<T: Deref<Target = Block>, PINS> eh1::Read for I2C<T, PINS, Controller> {
+        type Error = Error;
+
+        fn read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Error> {
+            Read::read(self, addr, buffer)
+        }
+    }
+}


### PR DESCRIPTION
This allows to simplify instantiation using only:

```rust
let mut i2c_pio = i2c_pio::I2C::new(
    &mut pio,
    pins.gpio0,
    pins.gpio10,
    sm0,
    400_000.Hz(),
    clocks.system_clock.freq()
);
```

instead of 
```rust
let mut i2c_pio = i2c_pio::I2C::<_, _, _, _, hal::gpio::FunctionPio0>::new(
    &mut pio,
    pins.gpio0,
    pins.gpio10,
    sm0,
    400_000.Hz(),
    clocks.system_clock.freq(),
);
```