### PR TITLE
Upgrade pio to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ eh1_0_alpha = { version = "=1.0.0-alpha.5", package = "embedded-hal", optional =
 embedded-hal = "0.2.6"
 embedded-time = "0.12.0"
 nb = "1.0.0"
-pio = "0.1.0"
+pio = "0.2.0"
 rp2040-hal = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "i2c-pio"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 license = "Apache-2.0"
 description = "I2C driver implementation using the RP2040's PIO peripheral."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,7 +163,7 @@ where
         // SCL rising edge
         a.nop_with_delay_and_side_set(2, 1);
         // Allow clock to be stretched
-        a.wait_with_delay(1, pio::WaitSource::GPIO, SCL::DYN.num, 4);
+        a.wait_with_delay(1, pio::WaitSource::GPIO, SCL::DYN.num, false, 4);
         // Sample read data in middle of SCL pulse
         a.in_with_delay(pio::InSource::PINS, 1, 7);
         // SCL falling edge
@@ -175,7 +175,7 @@ where
         // SCL risin edge
         a.nop_with_delay_and_side_set(7, 1);
         // Allow clock to be stretched
-        a.wait_with_delay(1, pio::WaitSource::GPIO, SCL::DYN.num, 7);
+        a.wait_with_delay(1, pio::WaitSource::GPIO, SCL::DYN.num, false, 7);
         // Test SDA for ACK/NACK, fall through if ACK
         a.jmp_with_delay_and_side_set(pio::JmpCondition::PinHigh, &mut handle_nack, 2, 0);
 


### PR DESCRIPTION
Same as https://github.com/ithinuel/ws2812-pio-rs/pull/10.
In this case, a small fix was necessary due to an API change of `wait_with_delay`.